### PR TITLE
Add snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: tidy-viewer
+adopt-info: tidy-viewer
+summary: Tidy Viewer (tv)
+description: |
+  Tidy Viewer (tv) is a cross-platform CLI csv pretty printer that uses column styling to maximize viewer enjoyment.
+base: core20
+
+parts:
+  tidy-viewer:
+    source: https://github.com/alexhallam/tv.git
+    plugin: rust
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags --abbrev=0)"
+
+apps:
+  tidy-viewer:
+    command: bin/tidy-viewer
+
+confinement: strict


### PR DESCRIPTION
Adds a `snapcraft.yaml` which can be used to build `tidy-viewer` as a snap and publish it to the [Snap Store](http://snapcraft.io).

I've built it successfully on my machine. :slightly_smiling_face: 