### PR TITLE
Pass file as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ cat diamonds.csv | tv
 ### Starwars
 ```sh
 wget https://raw.githubusercontent.com/tidyverse/dplyr/master/data-raw/starwars.csv
-cat starwars.csv | tv
+
+# Pass as agrument
+tv starwars.csv
 ```
 
 ### Pigeon Racing


### PR DESCRIPTION
Allows users to pass file path as specified as mentioned in issue #49. Now it is possible to use `$ tv data.csv` to view csv file.
