### PR TITLE
Use an enum instead of str to store type information + small clippy fix

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -97,9 +97,7 @@ pub fn is_na_string_padded(text: &str) -> bool {
 // utilities
 
 pub fn infer_type_from_string(text: &str) -> ValueType {
-    if text.is_empty() {
-        ValueType::Na
-    } else if is_time(text) {
+    if is_time(text) {
         ValueType::Time
     } else if is_logical(text) {
         ValueType::Boolean
@@ -111,7 +109,9 @@ pub fn infer_type_from_string(text: &str) -> ValueType {
         ValueType::Date
     } else if is_double(text) {
         ValueType::Double
-    } else {
+    } else if text.is_empty() | is_na(text) {
+        ValueType::Na
+    } else{
         ValueType::Character
     }
 }

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -183,7 +183,7 @@ pub fn format_if_num(text: &str) -> String {
 
 pub fn get_col_data_type(col: &[&str]) -> ValueType {
     // counts the frequency of the datatypes in the column
-    // returns the most frequent. todo-make na not count and handle ties
+    // returns the most frequent while ignoring NA values.
     col.iter()
         .map(|x| infer_type_from_string(x))
         .filter(|x| !matches!(x, &ValueType::Na))

--- a/src/datatype/sigfig.rs
+++ b/src/datatype/sigfig.rs
@@ -82,14 +82,11 @@ impl DecimalSplits {
         )
     }
     pub fn rhs_string_len(&self, string_final_string: String) -> usize {
-        let split = string_final_string.split(".");
-        let vec = split.collect::<Vec<&str>>();
-        if vec.len() > 1 {
-            let length = vec[1].len();
-            length
-        } else {
-            0
-        }
+        string_final_string
+            .split('.')
+            .nth(1)
+            .map(|decimals| decimals.len())
+            .unwrap_or(0)
     }
     pub fn sigfig_index_lhs_or_rhs(&self) -> Option<bool> {
         sigfig_index_lhs_or_rhs(&self.final_string(), self.sig_fig())

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,9 +198,9 @@ fn main() {
 
     if debug_mode {
         // make datatypes vector
-        let mut vec_datatypes: Vec<&str> = vec!["#"; cols as usize];
-        for i in 0..cols {
-            vec_datatypes[i] = datatype::get_col_data_type(&v[i]);
+        let mut vec_datatypes = Vec::with_capacity(cols);
+        for column in &v {
+            vec_datatypes.push(datatype::get_col_data_type(&column))
         }
         println!("{:?}", "vec_datatypes");
         println!("{:?}", vec_datatypes);


### PR DESCRIPTION
Enum variants need less memory and are faster to compare. Both of which are of no practical importance considering it's only used to print debug information. Also contains two small fixes for clippy warnings in `rhs_string_len`.