### PR TITLE
Detect floats using `f64::from_str`

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
 use unicode_truncate::UnicodeTruncateStr;
+use std::str::FromStr;
 
 mod sigfig;
 
@@ -24,13 +25,7 @@ pub fn is_integer(text: &str) -> bool {
 }
 
 pub fn is_double(text: &str) -> bool {
-    lazy_static! {
-        // for exp values, but seems to match other strings also
-        //static ref R: Regex = Regex::new(r"[+-]?[0-9]+(\.[0-9]+)?([Ee][+-]?[0-9]+)?").unwrap();
-        static ref R: Regex = Regex::new(r"^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$").unwrap();
-
-    }
-    R.is_match(text)
+    f64::from_str(text).is_ok()
 }
 
 pub fn is_time(text: &str) -> bool {

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
-use unicode_truncate::UnicodeTruncateStr;
 use std::str::FromStr;
+use unicode_truncate::UnicodeTruncateStr;
 
 mod sigfig;
 


### PR DESCRIPTION
Std provides the [`from_str`](https://doc.rust-lang.org/1.55.0/std/primitive.f64.html#method.from_str) method to parse strings into `f64`. The list of matching patterns seems to be fairly complete.

This should fix #25.