### PR TITLE
Adds new extend-rows flag (-e) to disable truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.4.4 (2021-11-18)
+==================
+
+* **Feature 1**  Added -e flag to extend rows (don't truncate).
+
+This new version gives a flag option to extend rows rather than truncate. This is especially useful for wide csv files that would overflow the terminal width. When using the extend mode, pipe output to `less -S` to enables scrolling right and left with arrow keys.
+
 1.4.3 (2021-11-17)
 ==================
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Unlicense/MIT"
 name = "tidy-viewer"
 readme = "README.md"
 repository = "https://github.com/alexhallam/tv"
-version = "1.4.3"
+version = "1.4.4"
 
 [package.metadata.deb]
 assets = [

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ For information on dotfile configuration see `tv --help`. This allows users to s
 `tv --help`
 
 ```txt
-tv 1.4.3
+tv 1.4.4
 Tidy Viewer (tv) is a csv pretty printer that uses column styling to maximize viewer enjoyment.✨✨📺✨✨
 
     Example Usage:
@@ -338,6 +338,8 @@ Tidy Viewer (tv) is a csv pretty printer that uses column styling to maximize vi
         #lower_column_width = 2
         ## head number of rows to output <row-display> [default: 25]
         #number = 35
+        ## extend rows beyond term width (do not trucate) [default: false]
+        # extend_rows = true
         ## meta_color = [R,G,B] color for row index and "tv dim: rowsxcols"
         #meta_color = [64, 179, 162]
         ## header_color = [R,G,B] color for column headers
@@ -354,6 +356,7 @@ USAGE:
 
 FLAGS:
     -d, --debug-mode      Print object details to make it easier for the maintainer to find and resolve bugs.
+    -e, --extend-rows     Extended row beyond term width (do not truncate). Useful with `less -S`.
     -a, --color-always    Always force color output. Example `tv -a starwars.csv | less -R` or `tv -a starwars.csv | bat
                           -p`. The `less` cli has the `-R` flag to parse colored output.
     -h, --help            Prints help information


### PR DESCRIPTION
Adds a new extend-rows flag (-e) which allows the user to disable row
truncation. This is super helpful for wide csv files that are larger
than the terminal width. When using this flag, pipe output to `less -S`
to be able to use the arrow keys to scroll right and left to actually
view the overflowing columns.

Eg: 

`tidy-viewer -e wide.csv | less -S`

Or even... to preserve colors through less...

`tidy-viewer -a -e wide.csv | less -S`.


-----

Thanks for the awesome tool, btw!! Please consider this contribution, I have found it really helpful for working on a smaller screen with wide csv files. 

I bumped the version, updated readme, and changelog, but was uncertain about this aspect. Please request revisions or update as you see appropriate.
