### PR TITLE
TV doesn't respect the actual display width of the chars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,7 @@ dependencies = [
  "structopt",
  "toml",
  "unicode-truncate",
+ "unicode-width",
 ]
 
 [[package]]
@@ -607,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,4 @@ serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3.21"
 toml = "0.5"
 unicode-truncate = "0.2.0"
+unicode-width = "0.1.11"

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::str::FromStr;
+use unicode_width::UnicodeWidthStr;
 use unicode_truncate::UnicodeTruncateStr;
 
 mod sigfig;
@@ -182,7 +183,7 @@ pub fn format_strings(
 
                 string.push_str(&" ".repeat(max_fract - fract));
             }
-            let len = string.chars().count();
+            let len = UnicodeWidthStr::width(string.as_str());
             // the string and its length
             (string, len)
         })


### PR DESCRIPTION
Currently, TV doesn't format currently some double width unicode chars. Use the unicode-width crate so that we can get the correct display width for the unicode string.

For example, if there's Chinese characters, the formatting would be wrong currently. 

![image](https://github.com/alexhallam/tv/assets/3023614/46c2ec0c-98dc-4f5d-9117-a6398de8cc32)

After the change, 

![image](https://github.com/alexhallam/tv/assets/3023614/ac6b4904-cc9d-4bee-a9f0-ad7429d66b95)