### PR TITLE
Fix broken API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ After the above steps I would highly recommend you make an alias for `tidy-viewe
 
 📚 **Comprehensive documentation is available:**
 
-- **[📖 API Documentation](https://alexhallam.github.io/tv/)** - Rust API reference with examples
+- **[📖 API Documentation](https://alexhallam.github.io/tv/tidy_viewer_core/index.html)** - Rust API reference with examples
 - **[🏗️ Contributing Guide](CONTRIBUTING.md)** - Architecture overview and development guidelines
 - **[🐍 Python Documentation](tidy-viewer-py/README.md)** - Python bindings usage and examples
 


### PR DESCRIPTION
Fix broken API documentation link in README.md by updating the URL to the correct path.

---
<a href="https://cursor.com/background-agent?bcId=bc-f15a5cf8-7cc4-4f88-9992-659662f0db97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f15a5cf8-7cc4-4f88-9992-659662f0db97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

