### PR TITLE
Fix broken API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ After the above steps I would highly recommend you make an alias for `tidy-viewe
 
 📚 **Comprehensive documentation is available:**
 
-- **[📖 API Documentation](https://alexhallam.github.io/tv/)** - Rust API reference with examples
+- **[📖 API Documentation](https://docs.rs/tidy-viewer-core)** - Rust API reference with examples
 - **[🏗️ Contributing Guide](CONTRIBUTING.md)** - Architecture overview and development guidelines
 - **[🐍 Python Documentation](tidy-viewer-py/README.md)** - Python bindings usage and examples
 


### PR DESCRIPTION
Update broken API documentation link to point to docs.rs.

---
<a href="https://cursor.com/background-agent?bcId=bc-12441e5b-a986-478a-9dc3-fc8110488dd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12441e5b-a986-478a-9dc3-fc8110488dd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

