### PR TITLE
Debug and plan github actions fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,27 +33,27 @@ jobs:
             os: ubuntu-22.04
             rust: stable
           - build: macos-intel
-            os: macOS-13
+            os: macos-13
             rust: stable
           - build: macos-arm
-            os: macOS-14
+            os: macos-14
             rust: stable
           - build: win-msvc
             os: windows-2022
             rust: stable
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install packages (Ubuntu)
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          ci/ubuntu-install-packages
+          bash ci/ubuntu-install-packages
 
       - name: Install packages (macOS)
-        if: matrix.os == 'macOS-13'
+        if: startsWith(matrix.os, 'macos-')
         run: |
-          ci/macos-install-packages
+          bash ci/macos-install-packages
 
       - name: Set up Python
         if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+          components: clippy
 
       - name: Cache dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
Fixes CI and release workflow failures by correcting macOS runner labels, installing clippy, and updating actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-e57208c9-3067-456d-8101-03b73fdf8f13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e57208c9-3067-456d-8101-03b73fdf8f13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

