### PR TITLE
Changes from background agent bc-8b92343c-37d8-41c4-87ea-e7e489c807a4

### DIFF
--- a/.github/workflows/py-release.yml
+++ b/.github/workflows/py-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install maturin
         run: |
           python -m pip install --upgrade pip
-          pip install maturin[patchelf]
+          pip install maturin${{ runner.os == 'Linux' && '[patchelf]' || '' }}
 
       - name: Build wheel
         working-directory: tidy-viewer-py


### PR DESCRIPTION
Fix `maturin[patchelf]` installation failure on Windows/macOS by making it Linux-only.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b92343c-37d8-41c4-87ea-e7e489c807a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b92343c-37d8-41c4-87ea-e7e489c807a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

