### PR TITLE
Investigate na color change

### DIFF
--- a/tidy-viewer-cli/src/main.rs
+++ b/tidy-viewer-cli/src/main.rs
@@ -16,7 +16,7 @@ mod datatype;
 
 // Import from inline modules (formerly tidy_viewer_core)
 use crate::datatype::{
-    format_strings, get_col_data_type, is_na, is_negative_number,
+    format_strings, get_col_data_type, is_na, is_na_string_padded, is_negative_number,
     parse_delimiter,
 };
 
@@ -1317,7 +1317,7 @@ fn main() {
                 if is_tty || is_force_color {
                     let _ = match stdout!(
                         "{}",
-                        if is_na(col) {
+                        if is_na_string_padded(col) {
                             col.truecolor(na_color[0], na_color[1], na_color[2])
                         } else if is_negative_number(col) {
                             col.truecolor(neg_num_color[0], neg_num_color[1], neg_num_color[2])

--- a/tidy-viewer-py/src/formatting.rs
+++ b/tidy-viewer-py/src/formatting.rs
@@ -6,7 +6,7 @@ use std::io::BufReader;
 use unicode_width::UnicodeWidthStr;
 
 use crate::types::{ColorScheme, FormatOptions};
-use tidy_viewer_core::{calculate_column_width, format_strings, is_na, is_negative_number};
+use tidy_viewer_core::{calculate_column_width, format_strings, is_na, is_negative_number, is_na_string_padded};
 
 /// Main entry point for formatting tabular data
 pub fn format_table(
@@ -402,7 +402,7 @@ fn format_data_row_from_columns(
                 // Header row - use header color
                 let [r, g, b] = options.colors.header_color;
                 padded.truecolor(r, g, b).to_string()
-            } else if is_na(cell) {
+            } else if is_na_string_padded(cell) {
                 let [r, g, b] = options.colors.na_color;
                 padded.truecolor(r, g, b).to_string()
             } else if is_negative_number(cell) {


### PR DESCRIPTION
Restore NA cell coloring by using a whitespace-tolerant NA check after padding.

The previous `is_na` check was applied to padded strings (e.g., "NA     "), causing it to fail and default to white. Switching to `is_na_string_padded` ensures that padded NA values are correctly identified and colored.

---
<a href="https://cursor.com/background-agent?bcId=bc-577d1a98-8efa-4ea3-90ce-fedadad06a48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-577d1a98-8efa-4ea3-90ce-fedadad06a48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

