### PR TITLE
Restore coloring for NA values

### DIFF
--- a/tidy-viewer-cli/src/main.rs
+++ b/tidy-viewer-cli/src/main.rs
@@ -16,7 +16,7 @@ mod datatype;
 
 // Import from inline modules (formerly tidy_viewer_core)
 use crate::datatype::{
-    format_strings, get_col_data_type, is_na, is_negative_number,
+    format_strings, get_col_data_type, is_na, is_na_string_padded, is_negative_number,
     parse_delimiter,
 };
 
@@ -1179,7 +1179,7 @@ fn main() {
     }
 
     // title
-    if !is_na(&title_option.clone()) {
+    if !is_na_string_padded(&title_option.clone()) {
         let _ = match stdout!("{: >6}  ", "") {
             Ok(_) => Ok(()),
             Err(e) => match e.kind() {
@@ -1317,7 +1317,7 @@ fn main() {
                 if is_tty || is_force_color {
                     let _ = match stdout!(
                         "{}",
-                        if is_na(col) {
+                        if is_na_string_padded(col) {
                             col.truecolor(na_color[0], na_color[1], na_color[2])
                         } else if is_negative_number(col) {
                             col.truecolor(neg_num_color[0], neg_num_color[1], neg_num_color[2])
@@ -1466,7 +1466,7 @@ fn main() {
     }
 
     // footer
-    if !is_na(&footer_option.clone()) {
+    if !is_na_string_padded(&footer_option.clone()) {
         let _ = match stdout!("{: >6}  ", "") {
             Ok(_) => Ok(()),
             Err(e) => match e.kind() {


### PR DESCRIPTION
Re-enable coloring for NA values by using a padded-aware NA detection.

The previous `is_na` function did not correctly identify NA values after they had been padded for display alignment, causing them to appear white. Switching to `is_na_string_padded` restores the intended coloring.

---
<a href="https://cursor.com/background-agent?bcId=bc-99437034-d2b8-4e1e-90e9-61d6dd73948f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99437034-d2b8-4e1e-90e9-61d6dd73948f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

