### PR TITLE
Fix csv column overflow in python

### DIFF
--- a/tidy-viewer-py/Cargo.toml
+++ b/tidy-viewer-py/Cargo.toml
@@ -27,6 +27,7 @@ unicode-truncate = { workspace = true }
 lazy_static = { workspace = true }
 regex = { workspace = true }
 anyhow = "1.0"
+crossterm = { workspace = true }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Truncate columns and add 'N more variables' footer in Python output to match CLI's terminal width handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-84404008-9d2c-4b6e-82c7-0256a7bc6b8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84404008-9d2c-4b6e-82c7-0256a7bc6b8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

