### PR TITLE
Fix tidy-viewer-py build error

### DIFF
--- a/tidy-viewer-py/.gitignore
+++ b/tidy-viewer-py/.gitignore
@@ -74,6 +74,9 @@ venv.bak/
 .uv/
 .python-version
 
+# Copied tidy-viewer-core (created during build)
+tidy-viewer-core/
+
 
 
 

--- a/tidy-viewer-py/BUILD_INSTRUCTIONS.md
+++ b/tidy-viewer-py/BUILD_INSTRUCTIONS.md
@@ -1,0 +1,55 @@
+# Building tidy-viewer-py for PyPI
+
+This package has a dependency on `tidy-viewer-core`, which is a local Rust crate. To build and publish this package to PyPI, follow these steps:
+
+## Prerequisites
+
+- Python 3.8+
+- Rust toolchain
+- maturin (`pip install maturin`)
+
+## Building for Distribution
+
+1. **Prepare the build** - Copy tidy-viewer-core into the package:
+   ```bash
+   cd tidy-viewer-py
+   python prepare_build.py
+   ```
+
+2. **Build the source distribution and wheels**:
+   ```bash
+   maturin build --release
+   ```
+
+3. **For development/testing**:
+   ```bash
+   maturin develop
+   ```
+
+## Publishing to PyPI
+
+1. Prepare the build as described above
+2. Build the wheels:
+   ```bash
+   maturin build --release
+   ```
+3. Upload to PyPI:
+   ```bash
+   maturin publish
+   ```
+
+## Important Notes
+
+- The `prepare_build.py` script copies `tidy-viewer-core` into the package directory and updates all workspace dependencies to concrete versions
+- The copied `tidy-viewer-core` directory is git-ignored and should not be committed
+- Always run `prepare_build.py` before building or publishing
+- The `MANIFEST.in` file ensures that all necessary files are included in the source distribution
+
+## Testing the Package
+
+After building, you can test the package installation:
+
+```bash
+pip install dist/tidy_viewer_py-*.whl
+python -c "import tidy_viewer_py; print('Import successful!')"
+```

--- a/tidy-viewer-py/Cargo.toml
+++ b/tidy-viewer-py/Cargo.toml
@@ -14,20 +14,21 @@ name = "tidy_viewer_py"
 crate-type = ["cdylib"]
 
 [dependencies]
-tidy-viewer-core = { path = "../tidy-viewer-core" }
+# Temporarily use path dependency - we'll need to vendor this
+tidy-viewer-core = { path = "./tidy-viewer-core" }
 pyo3 = { version = "0.25", features = ["extension-module"] }
-csv = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-arrow = { workspace = true }
-parquet = { workspace = true }
-owo-colors = { workspace = true }
-unicode-width = { workspace = true }
-unicode-truncate = { workspace = true }
-lazy_static = { workspace = true }
-regex = { workspace = true }
+csv = "1.1.6"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+arrow = "56.0"
+parquet = "56.0"
+owo-colors = "3.0.1"
+unicode-width = "0.1.11"
+unicode-truncate = "0.2.0"
+lazy_static = "1.4.0"
+regex = "1.5.4"
 anyhow = "1.0"
-crossterm = { workspace = true }
+crossterm = "0.22.1"
 
 [profile.release]
 lto = true

--- a/tidy-viewer-py/MANIFEST.in
+++ b/tidy-viewer-py/MANIFEST.in
@@ -1,0 +1,11 @@
+include Cargo.toml
+include pyproject.toml
+include README.md
+include LICENSE
+include UNLICENSE
+recursive-include src *.rs *.py *.pyi
+recursive-include tidy-viewer-core *.rs *.toml
+recursive-include tests *.py
+exclude .gitignore
+exclude uv.lock
+prune .github

--- a/tidy-viewer-py/prepare_build.py
+++ b/tidy-viewer-py/prepare_build.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Prepare the package for building by copying tidy-viewer-core into the package directory.
+This ensures that the relative path dependency works when building from PyPI.
+"""
+
+import shutil
+import os
+import sys
+from pathlib import Path
+
+def prepare_build():
+    # Get the directory where this script is located
+    script_dir = Path(__file__).parent
+    
+    # Paths
+    source_core_dir = script_dir.parent / "tidy-viewer-core"
+    target_core_dir = script_dir / "tidy-viewer-core"
+    
+    # Check if source exists
+    if not source_core_dir.exists():
+        print(f"Error: tidy-viewer-core not found at {source_core_dir}")
+        sys.exit(1)
+    
+    # Remove existing directory if it exists
+    if target_core_dir.exists():
+        print(f"Removing existing {target_core_dir}")
+        shutil.rmtree(target_core_dir)
+    
+    # Copy the directory
+    print(f"Copying {source_core_dir} to {target_core_dir}")
+    shutil.copytree(source_core_dir, target_core_dir)
+    
+    # Update the Cargo.toml files to remove workspace dependencies
+    # First, fix tidy-viewer-core/Cargo.toml
+    cargo_toml_path = target_core_dir / "Cargo.toml"
+    if cargo_toml_path.exists():
+        print(f"Updating {cargo_toml_path} to remove workspace dependencies")
+        
+        # Read the file
+        with open(cargo_toml_path, 'r') as f:
+            content = f.read()
+        
+        # Replace workspace dependencies with concrete versions
+        # These versions match the workspace Cargo.toml
+        replacements = {
+            'lazy_static = { workspace = true }': 'lazy_static = "1.4.0"',
+            'regex = { workspace = true }': 'regex = "1.5.4"',
+            'unicode-truncate = { workspace = true }': 'unicode-truncate = "0.2.0"',
+            'unicode-width = { workspace = true }': 'unicode-width = "0.1.11"',
+            'itertools = { workspace = true }': 'itertools = "0.10.0"',
+        }
+        
+        for old, new in replacements.items():
+            content = content.replace(old, new)
+        
+        # Write back
+        with open(cargo_toml_path, 'w') as f:
+            f.write(content)
+    
+    # Also fix the main tidy-viewer-py/Cargo.toml
+    main_cargo_toml = script_dir / "Cargo.toml"
+    if main_cargo_toml.exists():
+        print(f"Updating {main_cargo_toml} to remove workspace dependencies")
+        
+        with open(main_cargo_toml, 'r') as f:
+            content = f.read()
+        
+        # Replace workspace dependencies
+        workspace_deps = {
+            'csv = { workspace = true }': 'csv = "1.1.6"',
+            'serde = { workspace = true }': 'serde = { version = "1.0", features = ["derive"] }',
+            'serde_json = { workspace = true }': 'serde_json = "1.0"',
+            'arrow = { workspace = true }': 'arrow = "56.0"',
+            'parquet = { workspace = true }': 'parquet = "56.0"',
+            'owo-colors = { workspace = true }': 'owo-colors = "3.0.1"',
+            'unicode-width = { workspace = true }': 'unicode-width = "0.1.11"',
+            'unicode-truncate = { workspace = true }': 'unicode-truncate = "0.2.0"',
+            'lazy_static = { workspace = true }': 'lazy_static = "1.4.0"',
+            'regex = { workspace = true }': 'regex = "1.5.4"',
+            'crossterm = { workspace = true }': 'crossterm = "0.22.1"',
+        }
+        
+        for old, new in workspace_deps.items():
+            content = content.replace(old, new)
+        
+        with open(main_cargo_toml, 'w') as f:
+            f.write(content)
+    
+    print("Build preparation complete!")
+
+if __name__ == "__main__":
+    prepare_build()


### PR DESCRIPTION
Make `tidy-viewer-py` installable from PyPI by vendoring `tidy-viewer-core` and updating build configurations.

The previous setup with a relative path dependency to `tidy-viewer-core` failed during PyPI installation because the `tidy-viewer-core` directory was not part of the distributed package. These changes ensure the package is self-contained by copying `tidy-viewer-core`'s source into the package and replacing workspace dependencies with concrete versions before building.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b8ff70e-6f98-4e23-87cd-9f27fef1059b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b8ff70e-6f98-4e23-87cd-9f27fef1059b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

