### PR TITLE
Fix tidy-viewer-py build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["tidy-viewer-core", "tidy-viewer-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.8.93"
+version = "1.8.94"
 authors = ["alexhallam <alexhallam6.28@gmail.com>"]
 edition = "2021"
 license = "Unlicense OR MIT"

--- a/tidy-viewer-core/Cargo.toml
+++ b/tidy-viewer-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tidy-viewer-core"
-version = "1.8.93"
+version = "1.8.94"
 authors = ["alexhallam <alexhallam6.28@gmail.com>"]
 edition = "2021"
 license = "Unlicense OR MIT"

--- a/tidy-viewer-py/MANIFEST.in
+++ b/tidy-viewer-py/MANIFEST.in
@@ -1,0 +1,7 @@
+include Cargo.toml
+include src/**/*.rs
+include ../tidy-viewer-core/Cargo.toml
+include ../tidy-viewer-core/src/**/*.rs
+include README.md
+include LICENSE
+include UNLICENSE

--- a/tidy-viewer-py/pyproject.toml
+++ b/tidy-viewer-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidy-viewer-py"
-version = "0.2.94"
+version = "1.8.94"
 description = "A cross-platform data pretty printer that uses column styling to maximize viewer enjoyment. Supports CSV, Parquet, Pandas, and Polars DataFrames."
 readme = "README.md"
 authors = [{ name = "Alex Hallam", email = "alexhallam6.28@gmail.com" }]
@@ -25,7 +25,6 @@ classifiers = [
 ]
 keywords = ["table", "formatting", "terminal", "pretty-print", "csv", "parquet"]
 dependencies = [
-    "maturin>=1.9.3",
     "pandas>=2.0.3",
     "polars>=1.8.2",
     "pyarrow>=17.0.0",
@@ -55,6 +54,7 @@ build-backend = "maturin"
 python-source = "src"
 module-name = "tidy_viewer_py._core"
 features = ["pyo3/extension-module"]
+manylinux = "2_17"
 
 [tool.ruff]
 line-length = 100

--- a/tidy-viewer-py/src/tidy_viewer_py/__init__.py
+++ b/tidy-viewer-py/src/tidy_viewer_py/__init__.py
@@ -29,7 +29,7 @@ except ImportError as e:
     RUST_AVAILABLE = False
     _import_error = e
 
-__version__ = "0.2.94"
+__version__ = "1.8.94"
 __all__ = [
     "print_table", "print_csv", "print_parquet", "print_arrow", "print_dataframe", 
     "format_table", "format_csv", "format_parquet", "format_arrow", "format_dataframe",


### PR DESCRIPTION
Align package versions and include Rust source files in the Python distribution to fix build failures during installation.

The package failed to build during installation because `maturin` could not find the `Cargo.toml` for `tidy-viewer-core`. This was due to `tidy-viewer-py` having a relative path dependency on `tidy-viewer-core` within a monorepo structure, which breaks when the Python package is built in isolation. The `MANIFEST.in` file ensures the necessary Rust source files are included in the distributed package, allowing `maturin` to find them. Additionally, version inconsistencies and an incorrect `maturin` dependency were resolved.

---
<a href="https://cursor.com/background-agent?bcId=bc-79ca64c8-28f3-491b-9e91-8834e332d71c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79ca64c8-28f3-491b-9e91-8834e332d71c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

